### PR TITLE
- Use Express for routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon src/index.js",
+    "start": "node src/index.js",
     "lint": "eslint src/*.js",
     "format": "prettier src/* --ignore-path ./.gitignore"
   },
@@ -21,16 +21,16 @@
   "homepage": "https://github.com/khayes133/monkeywrench#readme",
   "devDependencies": {
     "eslint": "^8.43.0",
-    "nodemon": "^2.0.22",
     "prettier": "^2.8.8"
   },
   "dependencies": {
-    "@apollo/server": "^4.7.4",
+    "apollo-server-express": "^3.12.0",
+    "express": "^4.18.2",
     "graphql": "^16.6.0",
     "mongodb": "^5.6.0",
     "mongoose": "^7.3.0"
   },
   "engines": {
-    "node": ">=18.0.0" 
+    "node": ">=18.0.0"
   }
 }

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -31,7 +31,7 @@ const typeDefs = `#graphql
   }
   
   """
-  Use this for User quer input
+  Use this for User query input
   """
   input UserInput {
     username: String,
@@ -180,4 +180,23 @@ const typeDefs = `#graphql
 
 `;
 
-module.exports = typeDefs;
+// Dummy data
+const users = [
+  { _id: 1, username: "test1" },
+  { _id: 2, username: "test2" }
+];
+
+// Example resolvers
+const resolvers = {
+  Query: {
+    user: async (args, context) => {
+      return users[args.id];
+    },
+    users: async (args, context) => {
+      // return await Users.find();
+      return users;
+    }
+  }
+};
+
+module.exports = { typeDefs, resolvers };

--- a/src/index.js
+++ b/src/index.js
@@ -1,38 +1,19 @@
-const { ApolloServer } = require("@apollo/server");
-const { startStandaloneServer } = require("@apollo/server/standalone");
-const typeDefs = require("./graphql/schema");
-
-// Dummy data
-const users = [
-  { _id: 1, username: "test1" },
-  { _id: 2, username: "test2" }
-];
-
-// Example resolvers
-const resolvers = {
-  Query: {
-    user: async (args, context) => {
-      return users[args.id];
-    },
-    users: async (args, context) => {
-      // return await Users.find();
-      return users;
-    }
-  }
-};
-
-const server = new ApolloServer({
-  typeDefs,
-  resolvers
-});
+const express = require("express");
+const { ApolloServer } = require("apollo-server-express");
+const { typeDefs, resolvers } = require("./graphql/schema");
+const app = express();
 
 async function startServer() {
-  // Start the server at the specified port
-  const { url } = await startStandaloneServer(server, {
-    listen: { port: 4000 }
-  });
+  const server = new ApolloServer({ typeDefs, resolvers, introspection: true });
+  await server.start();
 
-  console.log(`🚀  Server ready at: ${url}`);
+  const graphqlPath = "/api/graphql";
+  server.applyMiddleware({ app, path: graphqlPath });
+
+  const port = 4000;
+  app.listen(port, () => {
+    console.log(`🚀 Server running on http://localhost:${port}${graphqlPath}`);
+  });
 }
 
 startServer();


### PR DESCRIPTION
- Move resolvers to src/graphql/schema.js
- Removing nodemon due to broken dependencies
- install apollo-server-express and express
- Remove empty /index.js file