### PR TITLE
Finally a fix to get introspection to work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "apollo-server-express": "^3.12.0",
     "express": "^4.18.2",
     "graphql": "^16.6.0",
+    "graphql-tools": "^9.0.0",
     "mongodb": "^5.6.0",
     "mongoose": "^7.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@apollo/server": "^4.7.4",
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "graphql": "^16.6.0",
     "graphql-tools": "^9.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const { expressMiddleware } = require("@apollo/server/express4");
 const { makeExecutableSchema } = require("@graphql-tools/schema");
 const express = require("express");
 const { json } = require("body-parser");
+const cors = require("cors");
 const { typeDefs, resolvers } = require("./graphql/schema");
 const app = express();
 
@@ -19,7 +20,7 @@ async function startServer() {
   await server.start();
 
   // Set the path for api calls
-  app.use("/graphql", json(), expressMiddleware(server));
+  app.use("/graphql", cors(), json(), expressMiddleware(server));
 
   const port = 4000;
   app.listen(port, () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,29 @@
+const { ApolloServer } = require("@apollo/server");
+const { expressMiddleware } = require("@apollo/server/express4");
+const { makeExecutableSchema } = require("@graphql-tools/schema");
 const express = require("express");
-const { ApolloServer } = require("apollo-server-express");
+const { json } = require("body-parser");
 const { typeDefs, resolvers } = require("./graphql/schema");
 const app = express();
 
 async function startServer() {
-  const server = new ApolloServer({ typeDefs, resolvers, introspection: true, playground: true });
+  const server = new ApolloServer({
+    schema: makeExecutableSchema({
+      typeDefs,
+      resolvers
+    }),
+    introspection: true
+  });
+
+  // Start the server
   await server.start();
 
-  const graphqlPath = "/api/graphql";
-  server.applyMiddleware({ app, path: graphqlPath });
+  // Set the path for api calls
+  app.use("/graphql", json(), expressMiddleware(server));
 
   const port = 4000;
   app.listen(port, () => {
-    console.log(`🚀 Server running on http://localhost:${port}${graphqlPath}`);
+    console.log(`🚀 Server running on http://localhost:${port}/graphql`);
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const { typeDefs, resolvers } = require("./graphql/schema");
 const app = express();
 
 async function startServer() {
-  const server = new ApolloServer({ typeDefs, resolvers, introspection: true });
+  const server = new ApolloServer({ typeDefs, resolvers, introspection: true, playground: true });
   await server.start();
 
   const graphqlPath = "/api/graphql";


### PR DESCRIPTION
We were on the right track with the code up to this point. The difference is that apollo-server-express is depreciated, and instead we should be using @apollo/server/express4's expressMiddleware to attach Apollo Server to an Express route. If you want to see it working, [check this out](https://test-monkeywrench.onrender.com/graphql)!

The difference between using Express with Apollo and using Apollo standalone are fairly major, but this is necessary for the OAuth implementation I had in mind. Since we are using Express, we can use the express-openid-connect package to automate the entire authentication chain for us, saving us a ton of coding! It will allow me to pass the user's data from the OAuth transaction through a context parameter so we can store the user's information in the database.